### PR TITLE
Use computed for queries so that they are lazy-loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,11 @@ export const query = (obj, prop, descriptor) => {
     : descriptor;
 
   return extendObservable(obj, {
-    [prop]: queryToObservable(client.watchQuery(options), {
-      onError,
-      onFetch
-    })
+    get [prop]() {
+      return queryToObservable(client.watchQuery(options), {
+        onError,
+        onFetch
+      });
+    }
   });
 };


### PR DESCRIPTION
Right now it appears that all queries are executed as soon as the store is instantiated. This makes it so you can't do the approach that mobx recommends where you use singletons or a "root store" https://mobx.js.org/best/store.html -- because that would load all queries that you use in the app as soon as the app started!

This turns the property into a computed so that the query is not executed until it is accessed for the first time.